### PR TITLE
Remove activation conditions for the plugin's configuration action

### DIFF
--- a/BrushSfx/actions/BrushSfx.action
+++ b/BrushSfx/actions/BrushSfx.action
@@ -9,8 +9,6 @@
         <whatsThis></whatsThis>
         <toolTip></toolTip>
         <iconText></iconText>
-        <activationFlags>10000</activationFlags>
-        <activationConditions>0</activationConditions>
         <shortcut>f8</shortcut>
         <isCheckable>false</isCheckable>
         <statusTip></statusTip>


### PR DESCRIPTION
Hi, I wrote about this problem on the Krita forum originally but then I decided to just open a PR. Copying the explanation below:

I’ve been using your plugin, and I love it. I’ve also been working on my own plugin that has a different purpose and I stumbled on a footgun in Krita [plugin development guide](https://docs.krita.org/sl/user_manual/python_scripting/krita_python_plugin_howto.html#creating-configurable-keyboard-shortcuts). It provides a template for the `.action` XML file and that template includes this configuration:

```xml
<activationFlags>10000</activationFlags>
```
I've noticed that you probably copied this value from the guide too, and used it in your plugin, however, I believe this is a bad default value for activation flags.

This value is specified in binary form in XML (kudos to ChatGPT for pointing me to [this code](https://invent.kde.org/graphics/krita/-/blob/master/libs/ui/kis_action_manager.cpp#L90) to understand this). So the value `10000` is `0x0010` in hexadecimal, which [means](https://invent.kde.org/graphics/krita/-/blob/master/libs/ui/kis_action.h#L47):

```cpp
 ACTIVE_DEVICE               = 0x0010, ///< Activate if the active node has a paint device, i.e. there are pixels to be modified
```

What this means is that when the user has a vector layer selected, the action becomes disabled. It took me quite a bunch of time and nerves to figure this out to fix this behavior for my plugin. It's not very important for your plugin, since people rarely have to go into the settings of Brush SFX plugin, but it can still rarely cause some confusion if someone wants to configure it while they have a vector layer active. Here is a screenshot of what I mean:

<img width="1920" height="906" alt="image" src="https://github.com/user-attachments/assets/97866229-f1aa-4fa9-a6b3-411dffb694e5" />

Notice how I have a vector layer selected in the layers docker, and the Brush SFX action in the Tools menu is disabled.

So I recommend either setting `<activationFlags>` to 0 for your plugin or removing that XML element completely (which is what I've noticed some [default built-in plugins](https://invent.kde.org/graphics/krita/-/blob/master/krita/data/actions/MoveTool.action#L6-13) do too).