### PR TITLE
Force PyQt6 for Krita 6.0 compatibility

### DIFF
--- a/BrushSfx/__init__.py
+++ b/BrushSfx/__init__.py
@@ -1,6 +1,14 @@
 import sys
 import os
 os.environ["SD_ENABLE_ASIO"] = "1"
+
+try:
+    from krita import Krita
+    major = int(Krita.instance().version().split('.')[0])
+    if major >= 6: os.environ["QT_PREFERRED_BINDING"] = "PyQt6"
+except Exception:
+    pass
+
 from .dependencies import *
 
 print("[BrushSfx] Checking for dependencies")


### PR DESCRIPTION
When starting Krita version 6.0.2.1 from CachyOS (Arch-based), I get the following error:
```
krita.scripting: "Traceback (most recent call last):"
krita.scripting: "  File \"/usr/lib/krita-python-libs/krita/__init__.py\", line 38, in importAvoidWrongPyQtHack"
krita.scripting: "    return import_real(name, globals, locals, fromlist, level)"
krita.scripting: "  File \"/home/estoyaburridow/.local/share/krita/pykrita/BrushSfx/__init__.py\", line 21, in <module>"
krita.scripting: "    from .brush_sfx import *"
krita.scripting: "  File \"/usr/lib/krita-python-libs/krita/__init__.py\", line 38, in importAvoidWrongPyQtHack"
krita.scripting: "    return import_real(name, globals, locals, fromlist, level)"
krita.scripting: "  File \"/home/estoyaburridow/.local/share/krita/pykrita/BrushSfx/brush_sfx.py\", line 599, in <module>"
krita.scripting: "    exten = BrushSFXExtension(Krita.instance())"
krita.scripting: "  File \"/home/estoyaburridow/.local/share/krita/pykrita/BrushSfx/brush_sfx.py\", line 42, in __init__"
krita.scripting: "    self.soundChanged.connect(self.player.setSoundSource)"
krita.scripting: "    ^^^^^^^^^^^^^^^^^^^^^^^^^"
krita.scripting: "AttributeError: 'PySide6.QtCore.Signal' object has no attribute 'connect'"
krita.scripting: "Could not import BrushSfx"
krita.scripting: Error loading plugin "BrushSfx"
```
This happens because Qt defaults to trying PySide6 first, then PyQt6.
Setting `QT_PREFERRED_BINDING=PyQt6` before any Qt import forces Qt to load PyQt6 directly, matching Krita's Qt binding.

Tested on versions 6.0.2.1 (Arch package) and 5.3.2.1 (AppImage).